### PR TITLE
testsuite: add Makefile which does nothing (needed for g.extension)

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -1,0 +1,4 @@
+null:
+	@:
+
+install:


### PR DESCRIPTION
Avoids `g.extension` error.