### PR TITLE
Ignore testsuite folder in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PGM = r.in.wcs
 # note: to deactivate a module, just place a file "DEPRECATED" into the subdir
 ALL_SUBDIRS := ${sort ${dir ${wildcard */.}}}
 DEPRECATED_SUBDIRS := ${sort ${dir ${wildcard */DEPRECATED}}}
-RM_SUBDIRS := bin/ docs/ etc/ scripts/
+RM_SUBDIRS := bin/ docs/ etc/ scripts/ testsuite/
 SUBDIRS_1 := $(filter-out $(DEPRECATED_SUBDIRS), $(ALL_SUBDIRS))
 SUBDIRS := $(filter-out $(RM_SUBDIRS), $(SUBDIRS_1))
 


### PR DESCRIPTION
This PR fixes 

```
GRASS twer/PERMANENT:~ > g.extension extension=r.in.wcs url=https://github.com/mundialis/r.in.wcs
Fetching <r.in.wcs> from
<https://github.com/mundialis/r.in.wcs/archive/main.zip> (be patient)...
Compiling...
make[1]: *** No targets specified and no makefile found.  Stop.
Installing...
make[1]: *** No rule to make target 'install'.  Stop.
make: *** [/usr/local/grass82/include/Make/Dir.make:19: installsubdirs] Error 2
WARNING: Installation failed, sorry. Please check above error messages.
```
Which installs the GRASS GIS addon partly - it works but e.g. doesn't appear in `g.search.modules` results.

With this addition, all is fine.

thanks to @anikaweinmann for the suggestion :)

Replaces #6